### PR TITLE
revisit presentation layer and small rendering issues

### DIFF
--- a/frontend-v3/src/app/components/player/player.component.css
+++ b/frontend-v3/src/app/components/player/player.component.css
@@ -30,6 +30,21 @@
     background-image: var(--backdrop-image-url);
 }
 
+.backdrop-with-image img {
+  position: relative;
+  z-index: 1;
+  max-width: 90%;
+  max-height: 90%;
+  object-fit: contain;
+  border-radius: 10px;
+  -webkit-mask-image: radial-gradient(circle, rgba(0,0,0,1) 80%, rgba(0,0,0,0) 100%);
+  mask-image: radial-gradient(circle, rgba(0,0,0,1) 80%, rgba(0,0,0,0) 100%);
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+  mask-position: center;
+}
+
 .backdrop-without-image {
     margin-top: 10vh;
     width: 80%;

--- a/frontend-v3/src/app/components/player/player.component.css
+++ b/frontend-v3/src/app/components/player/player.component.css
@@ -16,7 +16,7 @@
 .left-control-arrow { cursor: pointer; transform: scale(2); transition: 0.5s; color: white; }
 .right-control-arrow { cursor: pointer; transform: scale(2); transition: 0.5s; color: white; }
 .progress-spinner { z-index: 1; position: absolute; top: 50vh; transform: scale(1.5); opacity: 0.3; }
-.progress-bar { z-index: 1; width: 40vw; }
+.progress-bar { z-index: 1; width: 64vw; }
 .volume-up-icon { color: white; transform: scale(1); cursor: pointer; }
 .bottom-div { padding-top: 3vh; text-align: center; width: 80vw; }
 .disabled-icon { opacity: 0.5;  pointer-events: none; }

--- a/frontend-v3/src/app/components/player/player.component.css
+++ b/frontend-v3/src/app/components/player/player.component.css
@@ -24,16 +24,16 @@
 
 .backdrop-with-image {
     margin-top: 10vh;
-    width: 40vw;
-    height: 35vh;
+    width: 80%;
+    height: 50vh;
     background-size: contain;
     background-image: var(--backdrop-image-url);
 }
 
 .backdrop-without-image {
     margin-top: 10vh;
-    width: 40vw;
-    height: 35vh;
+    width: 80%;
+    height: 50vh;
     background: linear-gradient(rgb(54, 53, 53), rgb(193, 203, 200));
 }
 
@@ -107,8 +107,8 @@
     .shuffle-icon-enabled { color: rgb(158, 94, 242); transform: scale(1.5); transition: 1s; cursor: pointer; left: 7vw; position: absolute; }
     .shuffle-icon-disabled { color: white; transform: scale(1.0); transition: 1s; cursor: pointer; left: 7vw; position: absolute; }
 
-    .backdrop-with-image { margin-top: 10vh; width: 85vw; height: 30vh; }
-    .backdrop-without-image { margin-top: 10vh; width: 85vw; height: 30vh; }
+    .backdrop-with-image { margin-top: 5vh; width: 95vw; height: 50vh; }
+    .backdrop-without-image { margin-top: 5vh; width: 95vw; height: 50vh; }
 
     .progress-bar { width: 85vw; }
     .bottom-div { padding-top: 0vh; width: 100vw; }

--- a/frontend-v3/src/app/components/player/player.component.html
+++ b/frontend-v3/src/app/components/player/player.component.html
@@ -31,7 +31,7 @@
       <img [src]="getArtworkImageSrc()" style="position: relative; z-index: 1; max-width: 90%; max-height: 90%; object-fit: contain;"/>
     </div>
 
-    <mat-progress-bar class="progress-bar" *ngIf="getIsLoading()" mode="determinate" [value]="getDownloadProgress()"></mat-progress-bar>
+    <mat-progress-bar class="progress-bar" [style.visibility]="getIsLoading() ? 'visible' : 'hidden'" mode="determinate" [value]="getDownloadProgress()"></mat-progress-bar>
 
     <div fxLayout="row" fxLayoutAlign="space-evenly center">
       <h1 class="songTitle">{{ getTitle() }}</h1>
@@ -41,7 +41,7 @@
       <h3 class="songArtist">{{ getAuthor() }}</h3>
     </div>
 
-    <mat-spinner *ngIf="getIsLoading()" class="progress-spinner"></mat-spinner>
+    <mat-spinner [style.visibility]="getIsLoading() ? 'visible' : 'hidden'" class="progress-spinner"></mat-spinner>
 
     <div class="control-buttons" fxLayout="row" fxLayoutAlign="space-evenly center">
       <mat-icon *ngIf="shuffleEnabled" class="shuffle-icon-enabled" (click)="onClickShuffle()" fxFlex="10">shuffle</mat-icon>

--- a/frontend-v3/src/app/components/player/player.component.html
+++ b/frontend-v3/src/app/components/player/player.component.html
@@ -4,7 +4,19 @@
         <div id="backdrop" *ngIf="!getArtworkIsValid()" class="backdrop-without-image" fxLayout="row" fxLayoutAlign="space-evenly center">
             <mat-icon class="headset-backdrop-icon">headset</mat-icon>
         </div>
-        <div id="backdrop" *ngIf="getArtworkIsValid()" class="backdrop-with-image" fxLayout="row" fxLayoutAlign="space-evenly center" [style.--backdrop-image-url]="'url(' + getArtworkImageSrc() + ')'"></div>
+        <div
+            id="backdrop"
+            *ngIf="getArtworkIsValid()"
+            class="backdrop-with-image"
+            fxLayout="row"
+            fxLayoutAlign="space-evenly center"
+            [style.background-image]="'url(' + getArtworkImageSrc() + ')'"
+            style="
+                background-repeat: no-repeat;
+                background-size: cover;
+                background-position: center;
+            "
+        ></div>
         <mat-progress-bar class="progress-bar" *ngIf="getIsLoading()"  mode="determinate" [value]="getDownloadProgress()"></mat-progress-bar>
         <div fxLayout="row" fxLayoutAlign="space-evenly center">
             <h1 class="songTitle"> {{ getTitle() }}</h1>

--- a/frontend-v3/src/app/components/player/player.component.html
+++ b/frontend-v3/src/app/components/player/player.component.html
@@ -1,65 +1,88 @@
 <div class="player">
-    <div fxLayout="column" fxLayoutAlign="center center">
-        <app-header [hasPlaybackError]="hasPlaybackError"></app-header>
-        <div id="backdrop" *ngIf="!getArtworkIsValid()" class="backdrop-without-image" fxLayout="row" fxLayoutAlign="space-evenly center">
-            <mat-icon class="headset-backdrop-icon">headset</mat-icon>
-        </div>
-        <div
-            id="backdrop"
-            *ngIf="getArtworkIsValid()"
-            class="backdrop-with-image"
-            fxLayout="row"
-            fxLayoutAlign="space-evenly center"
-            [style.background-image]="'url(' + getArtworkImageSrc() + ')'"
-            style="
-                background-repeat: no-repeat;
-                background-size: cover;
-                background-position: center;
-            "
-        ></div>
-        <mat-progress-bar class="progress-bar" *ngIf="getIsLoading()"  mode="determinate" [value]="getDownloadProgress()"></mat-progress-bar>
-        <div fxLayout="row" fxLayoutAlign="space-evenly center">
-            <h1 class="songTitle"> {{ getTitle() }}</h1>
-        </div>
-        <div fxLayout="row" fxLayoutAlign="space-evenly center">
-            <h3 class="songArtist">{{ getAuthor() }} </h3>
-        </div>
-        <mat-spinner *ngIf="getIsLoading()" class="progress-spinner"></mat-spinner>
-        <div class="control-buttons" fxLayout="row" fxLayoutAlign="space-evenly center">
-            <mat-icon *ngIf="shuffleEnabled" class="shuffle-icon-enabled" (click)="onClickShuffle()" fxFlex="10">shuffle</mat-icon>
-            <mat-icon  *ngIf="!shuffleEnabled" class="shuffle-icon-disabled" (click)="onClickShuffle()" fxFlex="10">shuffle</mat-icon>
+  <div fxLayout="column" fxLayoutAlign="center center">
 
-            <mat-icon [attr.aria-disabled]="getIsLoading()" [ngClass]="{'disabled-ui-element': getIsLoading()}" class="left-control-arrow" (click)="onPrevious()" fxFlex="15">skip_previous</mat-icon>
-            <mat-icon *ngIf="!isPlaying"  class="play-pause-control" (click)="togglePlay()" fxFlex="40">play_arrow</mat-icon>
-            <mat-icon *ngIf="isPlaying" class="play-pause-control" (click)="togglePlay()" fxFlex="40">pause</mat-icon>
-            <mat-icon [attr.aria-disabled]="getIsLoading()" [ngClass]="{'disabled-ui-element': getIsLoading()}" class="right-control-arrow" (click)="onNext()" fxFlex="10">skip_next</mat-icon>
+    <!-- this header is only pertinent for me honestly (to remind myself when the last time a deployment occurred) -->
+    <!-- <app-header [hasPlaybackError]="hasPlaybackError"></app-header> -->
 
-            <mat-icon *ngIf="repeatEnabled" class="repeat-icon-enabled" (click)="onClickRepeat()" fxFlex="10">autorenew</mat-icon>
-            <mat-icon *ngIf="!repeatEnabled" class="repeat-icon-disabled" (click)="onClickRepeat()" fxFlex="10">autorenew</mat-icon>
-        </div>
-        <div fxLayout="row" fxLayoutAlign="space-evenly center">
-            <div fxLayout="column" fxLayoutAlign="center center">
-                <p class="current-time-text">{{ currentTimeHumanReadable }}&nbsp;&nbsp;</p>
-            </div>
-            <mat-slider (input)="onSeek($event)" step="0.005" min="0" [max]="duration" class="slider">
-                <input matSliderThumb [value]="currentTime"/>
-            </mat-slider>
-            <div fxLayout="column" fxLayoutAlign="center center">
-                <p class="duration-time-text">&nbsp;{{ durationHumanReadable }}</p>
-            </div>
-        </div>
-        <div fxLayout="row" fxLayoutAlign="space-evenly center" class="bottom-div">
-            <div fxLayout="column">
-                <a href="userExperienceReportUrl" target="_blank">
-                    <mat-icon class="ux-writeup-navigation-icon" matTooltip="view user experience report">description</mat-icon>
-                </a>
-            </div>
-            <div fxLayout="column">
-                <mat-icon [ngClass]="{'disabled-ui-element': getIsLoading()}" class="bottom-sheet-expand-icon" (click)="openBottomSheet()" matTooltip="select a song">menu</mat-icon>
-            </div>
-            <div fxLayout="column">
-                <mat-icon class="volume-up-icon" (click)="openCustomSnackBar()" matTooltip="adjust audio volume" [ngClass]="{'disabled-icon':!browserSupportsAudioVolumeManipulation}">volume_up</mat-icon>
-            </div>
-        </div>
+    <!-- no artwork present -->
+    <div id="backdrop" *ngIf="!getArtworkIsValid()" class="backdrop-without-image" fxLayout="row" fxLayoutAlign="space-evenly center">
+      <mat-icon class="headset-backdrop-icon">headset</mat-icon>
     </div>
+
+    <!-- artwork present -->
+    <div id="backdrop" *ngIf="getArtworkIsValid()" class="backdrop-with-image" fxLayout="row" fxLayoutAlign="center center" style="position: relative; overflow: hidden;">
+
+      <!-- blurred background layer -->
+      <div
+        style="
+          position: absolute;
+          inset: 0;
+          background-repeat: no-repeat;
+          background-size: cover;
+          background-position: center;
+          filter: blur(30px);
+          transform: scale(1.2);
+          z-index: 0;
+        "
+        [style.background-image]="'url(' + getArtworkImageSrc() + ')'"
+      ></div>
+
+      <!-- foreground image -->
+      <img [src]="getArtworkImageSrc()" style="position: relative; z-index: 1; max-width: 90%; max-height: 90%; object-fit: contain;"/>
+    </div>
+
+    <mat-progress-bar class="progress-bar" *ngIf="getIsLoading()" mode="determinate" [value]="getDownloadProgress()"></mat-progress-bar>
+
+    <div fxLayout="row" fxLayoutAlign="space-evenly center">
+      <h1 class="songTitle">{{ getTitle() }}</h1>
+    </div>
+
+    <div fxLayout="row" fxLayoutAlign="space-evenly center">
+      <h3 class="songArtist">{{ getAuthor() }}</h3>
+    </div>
+
+    <mat-spinner *ngIf="getIsLoading()" class="progress-spinner"></mat-spinner>
+
+    <div class="control-buttons" fxLayout="row" fxLayoutAlign="space-evenly center">
+      <mat-icon *ngIf="shuffleEnabled" class="shuffle-icon-enabled" (click)="onClickShuffle()" fxFlex="10">shuffle</mat-icon>
+      <mat-icon *ngIf="!shuffleEnabled" class="shuffle-icon-disabled" (click)="onClickShuffle()" fxFlex="10">shuffle</mat-icon>
+      <mat-icon [attr.aria-disabled]="getIsLoading()" [ngClass]="{'disabled-ui-element': getIsLoading()}" class="left-control-arrow" (click)="onPrevious()" fxFlex="15">skip_previous</mat-icon>
+      <mat-icon *ngIf="!isPlaying" class="play-pause-control" (click)="togglePlay()" fxFlex="40">play_arrow</mat-icon>
+      <mat-icon *ngIf="isPlaying" class="play-pause-control" (click)="togglePlay()" fxFlex="40">pause</mat-icon>
+      <mat-icon [attr.aria-disabled]="getIsLoading()" [ngClass]="{'disabled-ui-element': getIsLoading()}" class="right-control-arrow" (click)="onNext()" fxFlex="10">skip_next</mat-icon>
+      <mat-icon *ngIf="repeatEnabled" class="repeat-icon-enabled" (click)="onClickRepeat()" fxFlex="10">autorenew</mat-icon>
+      <mat-icon *ngIf="!repeatEnabled" class="repeat-icon-disabled" (click)="onClickRepeat()" fxFlex="10">autorenew</mat-icon>
+    </div>
+
+    <div fxLayout="row" fxLayoutAlign="space-evenly center">
+      <div fxLayout="column" fxLayoutAlign="center center">
+        <p class="current-time-text">{{ currentTimeHumanReadable }}&nbsp;&nbsp;</p>
+      </div>
+
+      <mat-slider (input)="onSeek($event)" step="0.005" min="0" [max]="duration" class="slider">
+        <input matSliderThumb [value]="currentTime" />
+      </mat-slider>
+
+      <div fxLayout="column" fxLayoutAlign="center center">
+        <p class="duration-time-text">&nbsp;{{ durationHumanReadable }}</p>
+      </div>
+    </div>
+
+    <div fxLayout="row" fxLayoutAlign="space-evenly center" class="bottom-div">
+
+      <div fxLayout="column">
+        <a href="{{userExperienceReportUrl}}" target="_blank">
+          <mat-icon class="ux-writeup-navigation-icon" matTooltip="view user experience report">description</mat-icon>
+        </a>
+      </div>
+
+      <div fxLayout="column">
+        <mat-icon [ngClass]="{'disabled-ui-element': getIsLoading()}" class="bottom-sheet-expand-icon" (click)="openBottomSheet()" matTooltip="select a song">menu</mat-icon>
+      </div>
+
+      <div fxLayout="column">
+        <mat-icon class="volume-up-icon" (click)="openCustomSnackBar()" matTooltip="adjust audio volume" [ngClass]="{'disabled-icon': !browserSupportsAudioVolumeManipulation}">volume_up</mat-icon>
+      </div>
+    </div>
+  </div>
 </div>

--- a/frontend-v3/src/app/services/audio.service.ts
+++ b/frontend-v3/src/app/services/audio.service.ts
@@ -64,6 +64,7 @@ export class AudioService {
         if (this.audioContext === null) return;
 
         this.buffer = await this.audioContext.decodeAudioData(arrayBuffer);
+        this.setDownloadProgress(0);
         this.setIsLoading(false);
         if (autoplay) {
             await this.play();
@@ -108,8 +109,8 @@ export class AudioService {
 
         if (mediaContext.length > 0) {
             let currentMediaContextElement: MediaContextElement = mediaContext[audioIndex];
-            this.setIsLoading(true);
             this.setDownloadProgress(0);
+            this.setIsLoading(true);
             audioFilenameHash = mediaContext[audioIndex].audio_filename_hash;
             this.setTitle(currentMediaContextElement.title);
             this.setAuthor(currentMediaContextElement.author);
@@ -134,6 +135,7 @@ export class AudioService {
                                     let decrypted = await this.cryptoService.decryptAudioData(encrypted, key);
                                     this.stop();
                                     this.loadFromArrayBuffer(decrypted, autoplay);
+                                    this.setDownloadProgress(0);
                                     this.setIsLoading(false);
                                     console.log('END getandloadaudiotrack');
                                 }


### PR DESCRIPTION
- keep loading bar and spinner from pushing other elements down (this prevents the "jumping" behavior between song loads)
- keep images from repeating
- add background and blur effect to make images look presentable and less jarring against the previous backdrop